### PR TITLE
210429 13:21

### DIFF
--- a/acmicpc_net/2104__/210429/9370.py
+++ b/acmicpc_net/2104__/210429/9370.py
@@ -6,7 +6,7 @@ input = sys.stdin.readline
 INF = int(10e9)
 
 def dijkstra(s):
-    D = [INF] * (n + 1) # prev, distance
+    D = [INF] * (n + 1) # distance
     pq = []
     hq.heappush(pq, (0, s))
     D[s] = 0


### PR DESCRIPTION
# 삽질 🤦🏻‍♂️

* Distance안의 원소를 ({이전_노드}, {가중치}) 형태로 삽입해서 입력받는 x마다 재귀 호출을 통해 g, h 경로를 거치면 출력하도록 했다.
-> 공간 복잡도가 2n이고 n이 최대 2,000이기 때문에 메모리 초과가 생길 수 있다. (메모리 제한 256MB)
* 완전 탐색으로 각 라운드마다 최소 가중치 인덱스를 찾아 출발지에서 모든 노드로의 가중치 값을 갱신하는 방법을 적용했다.
-> 최소 가중치 인덱스를 찾는 방법으로 우선순위 큐를 이용해보자.

# 후기 👨🏻‍💻

* 어느 한 경로를 지나가는지 확인하기 위해 다익스트라를 3번 돌린다는점이 신기했다. (시작, 노드 g, 노드 h를 출발점으로 다익스트라 알고리즘을 적용해 구한 Distance 테이블을 _s, _g, _h라고 했을 때...)
```
# 출발지에서 g로 가는 비용(_s[g]) + g에서 h로 가는 비용(_g[h]) + h에서 도착지로 가는 비용(_h[x]) == 출발지에서 x로 가는 비용(_s[x])과 같거나,
# 출 -> g -> h -> 도
# 출발지에서 h로 가는 비용(_s[h]) + h에서 g로 가는 비용(_h[g]) + g에서 도착지로 가는 비용(_g[x]) == 출발지에서 x로 가는 비용(_s[x])과 같으면
# 출 -> h -> g -> 도
if _s[g] + _g[h] + _h[x] == _s[x] or _s[h] + _h[g] + _g[x] == _s[x]:
    res.append(x)
```
다음을 꼭 기억해두자!