### PR TITLE
BOJ 15489 :: 파스칼 삼각형

### DIFF
--- a/acmicpc_net/2107__/210714/15489.py
+++ b/acmicpc_net/2107__/210714/15489.py
@@ -1,0 +1,19 @@
+import sys
+sys.stdin = open("./acmicpc_net/input.txt", "rt")
+input = sys.stdin.readline
+
+if __name__ == '__main__':
+    r, c, w = map(int, input().split())
+    D = [[1], [1, 1]]
+    size = 1
+
+    for L in range(3, r + w):
+        Item = [1] * L
+        for i in range(1, L - 1): Item[i] = D[-1][i - 1] + D[-1][i]
+        D.append(Item)
+    res, size = 0, 1
+    for i in range(r - 1, r + w - 1):
+        for j in range(size):
+            res += D[i][c - 1 + j]
+        size += 1
+    print(res)

--- a/acmicpc_net/input.txt
+++ b/acmicpc_net/input.txt
@@ -1,1 +1,1 @@
-baekjoon
+3 1 4


### PR DESCRIPTION
#### ** 📘 풀이한 문제 **

- 15489 :: 파스칼 삼각형 (https://www.acmicpc.net/problem/15489)

-----

#### ** ⭐ 문제에서 주로 사용한 알고리즘 **

- 15489 :: 파스칼 삼각형 (https://www.acmicpc.net/problem/15489)
    - 다이나믹 프로그래밍

-----

#### ** 📜 대략적인 코드 설명 **

**_파스칼 삼각형_**

- 배열 `D`의 인덱스 `i`에 위치하는 리스트는 파스칼 삼각형을 이루는 `i + 1`번째 줄 입니다.
- 초기 DP 배열 `D`의 초기화를 `=[[1], [1, 1]]`로 잡아줌으로써 파스칼 삼각형 구조를 만들기 위한 준비를 합니다.
- 그 이후 `D[2]` 부터 `D[2][i]` 값을 자신의 바로 왼쪽 위의 수`D[-1][i - 1]`와 바로 오른쪽 위의 수`D[-1][i]`의  합으로 결정짓게 됩니다.
- 그리고 이중 for문으로 해당 범위를 출력합니다.