### PR TITLE
210821

### DIFF
--- a/acmicpc_net/2103__/210312/16234.py
+++ b/acmicpc_net/2103__/210312/16234.py
@@ -26,11 +26,9 @@ if __name__ == '__main__':
 
                     while dq:
                         x, y = dq.popleft()
-
                         for k in range(4):
                             xx = x + dx[k]
                             yy = y + dy[k]
-
                             if (0 <= xx < n and 0 <= yy < n) and (l <= abs(A[xx][yy] - A[x][y]) <= r) and not visited[xx][yy]:
                                 visited[xx][yy] = True
                                 dq.append((xx, yy))

--- a/acmicpc_net/2108__/210821/1620.py
+++ b/acmicpc_net/2108__/210821/1620.py
@@ -1,0 +1,16 @@
+import sys
+sys.stdin = open("./acmicpc_net/input.txt", "rt")
+input = sys.stdin.readline
+
+if __name__ == '__main__':
+    n, m = map(int, input().split())    # 1 <= N, M <= 100,000
+    myList = [input().rstrip() for _ in range(n)]
+    pkmon1 = dict(zip(range(1, n + 1) , myList))
+    pkmon2 = dict(zip(myList , range(1, n + 1)))
+    
+    for _ in range(m):
+        query = input().rstrip()
+        if query.isdigit():
+            print(pkmon1.get(int(query)))
+        else:
+            print(pkmon2.get(query))

--- a/acmicpc_net/2108__/210821/16234.py
+++ b/acmicpc_net/2108__/210821/16234.py
@@ -1,0 +1,45 @@
+import sys
+from collections import deque
+sys.stdin = open("./acmicpc_net/input.txt", "rt")
+input = sys.stdin.readline
+''' 
+# TODO : BOJ 16234 예시 3번 (https://www.acmicpc.net/problem/16234)
+
+output : 3
+answer : 1
+'''
+
+dx = [-1, 0, 1, 0]
+dy = [0, 1, 0, -1]
+if __name__ == '__main__':
+    # (1 ≤ N ≤ 50, 1 ≤ L ≤ R ≤ 100)
+    n, l, r = map(int, input().split())
+    board = [list(map(int, input().split())) for _ in range(n)]
+    res = 0
+
+    while True:
+        visited = [[False] * n for _ in range(n)]
+        f = False
+        for i in range(n):
+            for j in range(n):
+                if not visited[i][j]:
+                    dq = []
+                    ptr = 0
+                    dq.append((i, j))
+                    visited[i][j] = True
+                    while ptr < len(dq):
+                        x, y = dq[ptr]
+                        ptr += 1
+                        for k in range(4):
+                            xx = x + dx[k]
+                            yy = y + dy[k]
+                            if (0 <= xx < n and 0 <= yy < n) and not visited[xx][yy] and (l <= abs(board[xx][yy] - board[x][y]) <= r):
+                                f = True
+                                dq.append((xx, yy))
+                                visited[xx][yy] = True
+                    avg = sum([board[x][y] for x, y in dq]) // len(dq)
+                    for s, t in dq: board[s][t] = avg
+        if not f:
+            break
+        res += 1
+    print(res)

--- a/acmicpc_net/input.txt
+++ b/acmicpc_net/input.txt
@@ -1,1 +1,32 @@
-4 3
+26 5
+Bulbasaur
+Ivysaur
+Venusaur
+Charmander
+Charmeleon
+Charizard
+Squirtle
+Wartortle
+Blastoise
+Caterpie
+Metapod
+Butterfree
+Weedle
+Kakuna
+Beedrill
+Pidgey
+Pidgeotto
+Pidgeot
+Rattata
+Raticate
+Spearow
+Fearow
+Ekans
+Arbok
+Pikachu
+Raichu
+25
+Raichu
+3
+Pidgey
+Kakuna

--- a/acmicpc_net/input.txt
+++ b/acmicpc_net/input.txt
@@ -1,32 +1,5 @@
-26 5
-Bulbasaur
-Ivysaur
-Venusaur
-Charmander
-Charmeleon
-Charizard
-Squirtle
-Wartortle
-Blastoise
-Caterpie
-Metapod
-Butterfree
-Weedle
-Kakuna
-Beedrill
-Pidgey
-Pidgeotto
-Pidgeot
-Rattata
-Raticate
-Spearow
-Fearow
-Ekans
-Arbok
-Pikachu
-Raichu
-25
-Raichu
-3
-Pidgey
-Kakuna
+4 10 50
+10 100 20 90
+80 100 60 70
+70 20 30 40
+50 20 100 10


### PR DESCRIPTION
#### ** 📘 풀이한 문제 **

* 76cd097 (HEAD -> 210821, origin/210821) BOJ 16234 :: 인구 이동
* 9b88fa5 BOJ 1620 :: 나는야 포켓몬 마스터 이다솜(문제 쓸떼없이 기네...)

-----

#### ** ⭐ 문제에서 주로 사용한 알고리즘 **
   
* 76cd097 (HEAD -> 210821, origin/210821) BOJ 16234 :: 인구 이동
    - BFS 탐색
* 9b88fa5 BOJ 1620 :: 나는야 포켓몬 마스터 이다솜(문제 쓸떼없이 기네...)
    - 자료구조 : 해시맵
-----

#### ** 📜 대략적인 코드 설명 **

**_나는야 포켓몬 마스터 이다솜_**
- 포켓몬 번호가 키값인 `pkmon1`과 포켓몬 이름이 키값인 `pkmon2`두 딕셔너리를 만든다음...
- 입력이 들어오면 `isdigit()`으로 질의를 구분한 뒤 `get()`으로 꺼내어 출력한다.
   
**_인구 이동_**
- 이중for문으로 `board`를 탐색하면서 처음 `not visited`인 위치에서 BFS 탐색을 시작한다.
- `dq`를 `popleft()`해버리면 인구값의 평균을 낼때 다시 구해야 하는 번거로움을 해소하기 위해 `ptr`로 이동하여 구한다. (~~근데 이 방법이 더 시간 걸리는것 같은데???~~)
- 배열 범위이면서 방문하지 않았고 인접한 두 칸의 차가 l이상 r이하라면 `dq`에 추가시키는 방식으로 BFS 탐색을 진행한다.
- `f`는 한번도 BFS 탐색을 진행하지 않았을 경우 빠져나오는 플래그 변수이다.
- 무한 루프를 빠져나오면 `res(걸린 날 일 횟수)`를 출력한다.
   