### PR TITLE
BOJ 2003 :: 수들의 합2

### DIFF
--- a/acmicpc_net/2112__/211203/2003.py
+++ b/acmicpc_net/2112__/211203/2003.py
@@ -1,0 +1,78 @@
+import sys
+sys.stdin = open("./acmicpc_net/input.txt", "rt")
+input = sys.stdin.readline
+
+#################################################################
+# 투 포인터(Two pointer), 슬라이딩 윈도우
+############################################################
+if __name__ == '__main__':
+    n, m = map(int, input().split())
+    arr = list(map(int, input().split()))
+    
+    lt, rt = 0, 0
+    cnt = 0
+    summation = sum(arr[lt:rt + 1])
+    while True:
+        if summation == m:
+            cnt += 1
+        
+        if summation < m:
+            rt += 1
+            if rt >= n: break
+            summation += arr[rt]
+        else:
+            summation -= arr[lt]
+            lt += 1
+            if lt >= n: break
+            if lt > rt:
+                rt += 1
+                summation = sum(arr[lt:rt + 1])
+    print(cnt)
+        
+
+#################################################################
+# 구간합 (Binary Index Tree)
+############################################################
+'''
+def prefixSummation(i):
+    res = 0
+    while i > 0:
+        res += tree[i]
+        i -= (i & -i)
+    return res
+
+# i번째 수를 diff만큼 업데이트 하는 함수
+def update(i, diff):
+    while i <= n:
+        tree[i] += diff
+        i += (i & -i)
+
+# 구간합을 구하는 함수
+def intervalSummation(start, end):
+    return prefixSummation(end) - prefixSummation(start - 1)
+
+if __name__ == '__main__':
+    # N(1 ≤ N ≤ 10,000), M(1 ≤ M ≤ 300,000,000)
+    n, m = map(int, input().split())
+    arr = [0] + list(map(int, input().split()))
+    tree = [0] * (n + 1)
+    
+    for i in range(1, n + 1):
+        update(i, arr[i])
+    
+    lt, rt = 1, 1
+    cnt = 0
+    while lt < n + 1 and rt < n + 1:
+        t = intervalSummation(lt, rt)
+        # 합이 m이 되는 경우 카운트
+        if t == m:
+            cnt += 1
+
+        if t < m:
+            rt += 1
+        else:   # t >= m
+            lt += 1
+            if lt > rt:
+                rt += 1
+    print(cnt)            
+'''

--- a/acmicpc_net/input.txt
+++ b/acmicpc_net/input.txt
@@ -1,8 +1,2 @@
-ZGBG
-X
-EE
-AAB
-AABA
-AABB
-BCBABCC
-*
+4 2
+1 1 1 1


### PR DESCRIPTION
#### ** 📘 풀이한 문제 **
  
* 3c2e4a4  (211203, origin/211203) BOJ 2003 :: 수들의 합2 (Fri Dec 3 16:41:41 2021 +0900) <Heongilee>
-----

#### ** ⭐ 문제에서 주로 사용한 알고리즘 **
  
* 3c2e4a4  (211203, origin/211203) BOJ 2003 :: 수들의 합2 (Fri Dec 3 16:41:41 2021 +0900) <Heongilee>
    - 구간합(BIT), 투 포인터, 슬라이딩 윈도우
-----

#### ** 📜 대략적인 코드 설명 **

**_수들의 합2_**
* 각 입력들을 받고(`n`, `m`, `arr`), 두 포인터 `lt`와 `rt`를 초기화 하여 해당 구간합(`summation`)을 구한다.
* 구간합(`summation`)이 `m `미만일 경우 값을 늘리기 위해 `rt+=1`을 해준다.
* 구간합이 `m`과 같거나 초과일 경우, 값을 `m`으로 줄이기 위해 `lt+=1`을 해준다.
* 구간을 이동하고나서는 해당 구간의 합이 `summation`과 같게 유지하도록 `summation`에 반영해준다.
* 슬라이딩 윈도우로 길이`n`만큼 탐색한 뒤에 결과값 `cnt`를 출력한다.